### PR TITLE
Added return statement to GetCommittedRegisterValue

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -23,5 +23,4 @@
 * Hendrik Eeckhaut - @heeckhau
 * Tim Ansell - @mithro
 * Felix Yan - @felixonmars
-
-
+* @odxa20

--- a/Processor/Src/SysDeps/Verilator/TestMain.cpp
+++ b/Processor/Src/SysDeps/Verilator/TestMain.cpp
@@ -53,6 +53,8 @@ int GetCommittedRegisterValue(
     for(int i = 0; i < LSCALAR_NUM; i++) {
         regData[i] = core->registerFile->phyReg->debugValue[phyRegNum[i]];
     }
+    
+    return 0;
 }
 
 


### PR DESCRIPTION
Added return statement to GetCommittedRegisterValue because in my system leaving this out makes the last for loop run forever and causes a segmentation fault due to out of bound access to the debugValue array