### PR TITLE
fix: make a small change to simulate with Verilator v4.222

### DIFF
--- a/Processor/Src/Cache/DCache.sv
+++ b/Processor/Src/Cache/DCache.sv
@@ -1431,6 +1431,8 @@ module DCacheMissHandler(
 
             // For flush
             mshrFlushComplete[i] = FALSE;
+            // For data merging
+            mergedLine[i] = '0;
 
             case(mshr[i].phase)
                 default: begin

--- a/Processor/Src/ExecUnit/IntALU.sv
+++ b/Processor/Src/ExecUnit/IntALU.sv
@@ -106,6 +106,8 @@ module IntALU(
         
         opA     = fuOpA_In;
         opB     = fuOpB_In;
+        signedOpA = '0;
+        signedOpB = '0;
         
         case( aluCode )
             // AND  論理積

--- a/Processor/Src/RenameLogic/RenameLogicCommitter.sv
+++ b/Processor/Src/RenameLogic/RenameLogicCommitter.sv
@@ -105,6 +105,8 @@ module RenameLogicCommitter(
 
         // The head and tail entries of an active list.
         alReadData = activeList.readData;
+        releaseNum = '0;
+        flushNum = '0;
 
         // Update control signals for the active list and the free lists in
         //  a rename logic.
@@ -138,7 +140,7 @@ module RenameLogicCommitter(
             end
 
             recovery.inRecoveryAL = FALSE;
-            flushNum = 0;
+            flushNum = '0;
         end
         else if(phase == PHASE_RECOVER_0) begin
             activeList.popHeadNum = 0;
@@ -148,7 +150,7 @@ module RenameLogicCommitter(
                 nextReleasedReg[i].phyReleasedReg = 0;
             end
             recovery.inRecoveryAL = TRUE;
-            flushNum = 0;
+            flushNum = '0;
         end
         else begin
 

--- a/Processor/Src/SysDeps/Verilator/TestMain.cpp
+++ b/Processor/Src/SysDeps/Verilator/TestMain.cpp
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
     // To access the module generated in generate,
     // use (Label given in generate section)__DOT__(module name)
     size_t mainMemWordSize = sizeof(top->Main_Zynq_Wrapper->main->memory->body->body__DOT__ram->array) / sizeof(uint32_t);
-    uint32_t* mainMem = (uint32_t*)(top->Main_Zynq_Wrapper->main->memory->body->body__DOT__ram->array);
+    uint32_t* mainMem = reinterpret_cast<uint32_t*>(&top->Main_Zynq_Wrapper->main->memory->body->body__DOT__ram->array);
 
     // Fill dummy data
     for (int i = 0; i < mainMemWordSize; i++) {


### PR DESCRIPTION
tiny fix to remove Verilator warning 'Warning-LATCH' and make it possible to simulate with Verilator v4.222(the latest stable version)