### PR TITLE
Fix a bug that causes incorrect recovery if all instructions are flushed when ActiveList is full

### DIFF
--- a/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerExecutionStage.sv
+++ b/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerExecutionStage.sv
@@ -184,6 +184,7 @@ module ComplexIntegerExecutionStage(
                     recovery.toRecoveryPhase, 
                     recovery.flushRangeHeadPtr, 
                     recovery.flushRangeTailPtr, 
+                    recovery.flushAllInsns,
                     regActiveListIndex[i]
                 );
             end
@@ -245,6 +246,7 @@ module ComplexIntegerExecutionStage(
                 recovery.toRecoveryPhase,
                 recovery.flushRangeHeadPtr,
                 recovery.flushRangeTailPtr,
+                recovery.flushAllInsns,
                 pipeReg[i].complexQueueData.activeListPtr
             );
 
@@ -255,6 +257,7 @@ module ComplexIntegerExecutionStage(
                     recovery.toRecoveryPhase, 
                     recovery.flushRangeHeadPtr, 
                     recovery.flushRangeTailPtr, 
+                    recovery.flushAllInsns,
                     localPipeReg[i][j-1].complexQueueData.activeListPtr 
                 );
             end

--- a/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerIssueStage.sv
+++ b/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerIssueStage.sv
@@ -48,6 +48,7 @@ module ComplexIntegerIssueStage(
                                         recovery.toRecoveryPhase,
                                         recovery.flushRangeHeadPtr,
                                         recovery.flushRangeTailPtr,
+                                        recovery.flushAllInsns,
                                         scheduler.complexIssuedData[i].activeListPtr
                                         );
             end
@@ -91,6 +92,7 @@ module ComplexIntegerIssueStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         issuedData[i].activeListPtr
                         );
 

--- a/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerRegisterReadStage.sv
+++ b/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerRegisterReadStage.sv
@@ -107,6 +107,7 @@ module ComplexIntegerRegisterReadStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         iqData[i].activeListPtr
                         );
             nextStage[i].valid =

--- a/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerRegisterWriteStage.sv
+++ b/Processor/Src/Pipeline/ComplexIntegerBackEnd/ComplexIntegerRegisterWriteStage.sv
@@ -70,6 +70,7 @@ module ComplexIntegerRegisterWriteStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         iqData[i].activeListPtr
                         );
             update[i] = !stall && !clear && valid[i] && !flush[i];

--- a/Processor/Src/Pipeline/IntegerBackEnd/IntegerExecutionStage.sv
+++ b/Processor/Src/Pipeline/IntegerBackEnd/IntegerExecutionStage.sv
@@ -154,6 +154,7 @@ module IntegerExecutionStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         iqData[i].activeListPtr
                         );
 

--- a/Processor/Src/Pipeline/IntegerBackEnd/IntegerIssueStage.sv
+++ b/Processor/Src/Pipeline/IntegerBackEnd/IntegerIssueStage.sv
@@ -45,6 +45,7 @@ module IntegerIssueStage(
                                         recovery.toRecoveryPhase,
                                         recovery.flushRangeHeadPtr,
                                         recovery.flushRangeTailPtr,
+                                        recovery.flushAllInsns,
                                         scheduler.intIssuedData[i].activeListPtr
                                         );
             end
@@ -87,6 +88,7 @@ module IntegerIssueStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         issuedData[i].activeListPtr
                         );
 

--- a/Processor/Src/Pipeline/IntegerBackEnd/IntegerRegisterReadStage.sv
+++ b/Processor/Src/Pipeline/IntegerBackEnd/IntegerRegisterReadStage.sv
@@ -173,6 +173,7 @@ module IntegerRegisterReadStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         iqData[i].activeListPtr
                         );
             nextStage[i].valid =

--- a/Processor/Src/Pipeline/IntegerBackEnd/IntegerRegisterWriteStage.sv
+++ b/Processor/Src/Pipeline/IntegerBackEnd/IntegerRegisterWriteStage.sv
@@ -77,6 +77,7 @@ module IntegerRegisterWriteStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         iqData[i].activeListPtr
                         );
             update[i] = !stall && !clear && valid[i] && !flush[i];

--- a/Processor/Src/Pipeline/MemoryBackEnd/MemoryAccessStage.sv
+++ b/Processor/Src/Pipeline/MemoryBackEnd/MemoryAccessStage.sv
@@ -88,6 +88,7 @@ module MemoryAccessStage(
                             recovery.toRecoveryPhase,
                             recovery.flushRangeHeadPtr,
                             recovery.flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             pipeReg[i].activeListPtr
                         );
             isStore[i] = pipeReg[i].isStore;

--- a/Processor/Src/Pipeline/MemoryBackEnd/MemoryExecutionStage.sv
+++ b/Processor/Src/Pipeline/MemoryBackEnd/MemoryExecutionStage.sv
@@ -105,6 +105,7 @@ module MemoryExecutionStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         iqData[i].activeListPtr
                         );
             memOpInfo[i]  = iqData[i].memOpInfo;
@@ -272,6 +273,7 @@ module MemoryExecutionStage(
                     recovery.toRecoveryPhase, 
                     recovery.flushRangeHeadPtr, 
                     recovery.flushRangeTailPtr, 
+                    recovery.flushAllInsns,
                     regActiveListIndex[i]
                 );
             end

--- a/Processor/Src/Pipeline/MemoryBackEnd/MemoryIssueStage.sv
+++ b/Processor/Src/Pipeline/MemoryBackEnd/MemoryIssueStage.sv
@@ -47,6 +47,7 @@ module MemoryIssueStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         scheduler.memIssuedData[i].activeListPtr
                     );
             end
@@ -90,6 +91,7 @@ module MemoryIssueStage(
                         recovery.toRecoveryPhase,
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         issuedData[i].activeListPtr
                         );
 

--- a/Processor/Src/Pipeline/MemoryBackEnd/MemoryRegisterReadStage.sv
+++ b/Processor/Src/Pipeline/MemoryBackEnd/MemoryRegisterReadStage.sv
@@ -155,6 +155,7 @@ module MemoryRegisterReadStage(
                 recovery.toRecoveryPhase,
                 recovery.flushRangeHeadPtr,
                 recovery.flushRangeTailPtr,
+                recovery.flushAllInsns,
                 iqData[i].activeListPtr
             );
             nextStage[i].valid =

--- a/Processor/Src/Pipeline/MemoryBackEnd/MemoryRegisterWriteStage.sv
+++ b/Processor/Src/Pipeline/MemoryBackEnd/MemoryRegisterWriteStage.sv
@@ -70,6 +70,7 @@ module MemoryRegisterWriteStage(
                 recovery.toRecoveryPhase,
                 recovery.flushRangeHeadPtr,
                 recovery.flushRangeTailPtr,
+                recovery.flushAllInsns,
                 pipeReg[i].activeListPtr
             );
             update[i] = !stall && !clear && valid[i] && !flush[i];

--- a/Processor/Src/Pipeline/MemoryBackEnd/MemoryTagAccessStage.sv
+++ b/Processor/Src/Pipeline/MemoryBackEnd/MemoryTagAccessStage.sv
@@ -119,6 +119,7 @@ module MemoryTagAccessStage(
                             recovery.toRecoveryPhase,
                             recovery.flushRangeHeadPtr,
                             recovery.flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             ldIqData[i].activeListPtr
                         );
             ldUpdate[i]  = ldPipeReg[i].valid && !stall && !clear && !ldFlush[i];
@@ -382,6 +383,7 @@ module MemoryTagAccessStage(
                             recovery.toRecoveryPhase,
                             recovery.flushRangeHeadPtr,
                             recovery.flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             stIqData[i].activeListPtr
                         );
             stUpdate[i]  = stPipeReg[i].valid && !stall && !clear && !stFlush[i];

--- a/Processor/Src/Pipeline/PipelineTypes.sv
+++ b/Processor/Src/Pipeline/PipelineTypes.sv
@@ -386,17 +386,18 @@ function automatic logic SelectiveFlushDetector(
     input logic detectRange,
     input ActiveListIndexPath headPtr,
     input ActiveListIndexPath tailPtr,
+    input logic flushAllInsns,
     input ActiveListIndexPath opPtr
 );
     if(!detectRange) begin
         return FALSE;
     end
+    else if (flushAllInsns) begin
+        return TRUE;
+    end
     else if(detectRange && tailPtr >= headPtr) begin
         //  |---h***i***t-------|
         if(opPtr >= headPtr && opPtr < tailPtr) begin
-            return TRUE;
-        end
-        else if (headPtr == tailPtr) begin
             return TRUE;
         end
         else begin
@@ -410,9 +411,6 @@ function automatic logic SelectiveFlushDetector(
         end
         //  |**i***t----h*******|
         else if(opPtr < headPtr && opPtr < tailPtr) begin
-            return TRUE;
-        end
-        else if (headPtr == tailPtr) begin
             return TRUE;
         end
         else begin

--- a/Processor/Src/Pipeline/PipelineTypes.sv
+++ b/Processor/Src/Pipeline/PipelineTypes.sv
@@ -396,6 +396,9 @@ function automatic logic SelectiveFlushDetector(
         if(opPtr >= headPtr && opPtr < tailPtr) begin
             return TRUE;
         end
+        else if (headPtr == tailPtr) begin
+            return TRUE;
+        end
         else begin
             return FALSE;
         end
@@ -407,6 +410,9 @@ function automatic logic SelectiveFlushDetector(
         end
         //  |**i***t----h*******|
         else if(opPtr < headPtr && opPtr < tailPtr) begin
+            return TRUE;
+        end
+        else if (headPtr == tailPtr) begin
             return TRUE;
         end
         else begin

--- a/Processor/Src/Recovery/RecoveryManagerIF.sv
+++ b/Processor/Src/Recovery/RecoveryManagerIF.sv
@@ -51,6 +51,8 @@ interface RecoveryManagerIF( input logic clk, rst );
     // Flush range to broadcast
     ActiveListIndexPath flushRangeHeadPtr;
     ActiveListIndexPath flushRangeTailPtr;
+    // Whether flush all instructions in ActiveList
+    // This is necessary to distinguish when ActiveList is full or empty, 
     logic flushAllInsns;
 
     // ActiveList/LSQ TailPtr for recovery

--- a/Processor/Src/Recovery/RecoveryManagerIF.sv
+++ b/Processor/Src/Recovery/RecoveryManagerIF.sv
@@ -51,6 +51,7 @@ interface RecoveryManagerIF( input logic clk, rst );
     // Flush range to broadcast
     ActiveListIndexPath flushRangeHeadPtr;
     ActiveListIndexPath flushRangeTailPtr;
+    logic flushAllInsns;
 
     // ActiveList/LSQ TailPtr for recovery
     LoadQueueIndexPath loadQueueRecoveryTailPtr;
@@ -173,6 +174,7 @@ interface RecoveryManagerIF( input logic clk, rst );
         toRecoveryPhase,
         flushRangeHeadPtr,
         flushRangeTailPtr,
+        flushAllInsns,
         notIssued,
         selected,
         selectedPtr,
@@ -208,6 +210,7 @@ interface RecoveryManagerIF( input logic clk, rst );
         toRecoveryPhase,
         flushRangeHeadPtr,
         flushRangeTailPtr,
+        flushAllInsns,
         recoveryFromRwStage,
     output
         replayQueueFlushedOpExist
@@ -218,6 +221,7 @@ interface RecoveryManagerIF( input logic clk, rst );
         toRecoveryPhase,
         flushRangeHeadPtr,
         flushRangeTailPtr,
+        flushAllInsns,
         selectedActiveListPtr,
         flushIQ_Entry,
         recoveryFromRwStage,
@@ -251,98 +255,112 @@ interface RecoveryManagerIF( input logic clk, rst );
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport IntegerRegisterReadStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport IntegerExecutionStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport IntegerRegisterWriteStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport ComplexIntegerIssueStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport ComplexIntegerRegisterReadStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport ComplexIntegerExecutionStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport ComplexIntegerRegisterWriteStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport MemoryIssueStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport MemoryRegisterReadStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport MemoryExecutionStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport MemoryTagAccessStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport MemoryAccessStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport MemoryRegisterWriteStage(
     input
         toRecoveryPhase,
         flushRangeHeadPtr,
-        flushRangeTailPtr
+        flushRangeTailPtr,
+        flushAllInsns
     );
 
     modport ActiveList(
@@ -357,7 +375,8 @@ interface RecoveryManagerIF( input logic clk, rst );
         refetchTypeFromRwStage,
         recoveredPC_FromCommitStage,
         recoveredPC_FromRwStage,
-        faultingDataAddr
+        faultingDataAddr,
+        flushAllInsns
     );
 
     modport InterruptController(

--- a/Processor/Src/RenameLogic/ActiveList.sv
+++ b/Processor/Src/RenameLogic/ActiveList.sv
@@ -272,7 +272,13 @@ module ActiveList(
         //リカバリをしなければならない命令はアクティブリストのtailからリカバリを起こした命令(またはその命令の後ろ)までのエントリにあたる
         flushRangeHeadPtr = recovery.flushRangeHeadPtr;
         flushRangeTailPtr = recovery.flushRangeTailPtr;
-        if (flushRangeTailPtr == flushRangeHeadPtr && count == ACTIVE_LIST_ENTRY_NUM) begin
+
+        // Calculate # of flush insts
+        if (flushRangeHeadPtr == flushRangeTailPtr 
+                        && count == ACTIVE_LIST_ENTRY_NUM) begin
+            // Flush all insts in ActiveList
+            // Because head and tail pointers match when ActiveList is full or empty,
+            // flushAllInsns is needed to distinguish between them
             nextRecoveryEntryNum = ACTIVE_LIST_ENTRY_NUM;
             recovery.flushAllInsns = TRUE;
         end

--- a/Processor/Src/RenameLogic/ActiveList.sv
+++ b/Processor/Src/RenameLogic/ActiveList.sv
@@ -272,8 +272,14 @@ module ActiveList(
         //リカバリをしなければならない命令はアクティブリストのtailからリカバリを起こした命令(またはその命令の後ろ)までのエントリにあたる
         flushRangeHeadPtr = recovery.flushRangeHeadPtr;
         flushRangeTailPtr = recovery.flushRangeTailPtr;
-        nextRecoveryEntryNum = (flushRangeTailPtr >= flushRangeHeadPtr) ?
+        if (flushRangeTailPtr == flushRangeHeadPtr) begin
+            nextRecoveryEntryNum = (count == ACTIVE_LIST_ENTRY_NUM) ?
+                                ACTIVE_LIST_ENTRY_NUM : '0;
+        end
+        else begin
+            nextRecoveryEntryNum = (flushRangeTailPtr >= flushRangeHeadPtr) ?
                                 flushRangeTailPtr - flushRangeHeadPtr : ACTIVE_LIST_ENTRY_NUM + flushRangeTailPtr - flushRangeHeadPtr;
+        end
         // RenameLogicCommitterにtoRecoveryPhase信号が
         // 届いた次のサイクルに信号を送る必要があるので,1サイクルの遅延を入れている
         port.recoveryEntryNum = recoveryEntryNum;

--- a/Processor/Src/RenameLogic/ActiveList.sv
+++ b/Processor/Src/RenameLogic/ActiveList.sv
@@ -272,13 +272,14 @@ module ActiveList(
         //リカバリをしなければならない命令はアクティブリストのtailからリカバリを起こした命令(またはその命令の後ろ)までのエントリにあたる
         flushRangeHeadPtr = recovery.flushRangeHeadPtr;
         flushRangeTailPtr = recovery.flushRangeTailPtr;
-        if (flushRangeTailPtr == flushRangeHeadPtr) begin
-            nextRecoveryEntryNum = (count == ACTIVE_LIST_ENTRY_NUM) ?
-                                ACTIVE_LIST_ENTRY_NUM : '0;
+        if (flushRangeTailPtr == flushRangeHeadPtr && count == ACTIVE_LIST_ENTRY_NUM) begin
+            nextRecoveryEntryNum = ACTIVE_LIST_ENTRY_NUM;
+            recovery.flushAllInsns = TRUE;
         end
         else begin
             nextRecoveryEntryNum = (flushRangeTailPtr >= flushRangeHeadPtr) ?
                                 flushRangeTailPtr - flushRangeHeadPtr : ACTIVE_LIST_ENTRY_NUM + flushRangeTailPtr - flushRangeHeadPtr;
+            recovery.flushAllInsns = FALSE;
         end
         // RenameLogicCommitterにtoRecoveryPhase信号が
         // 届いた次のサイクルに信号を送る必要があるので,1サイクルの遅延を入れている

--- a/Processor/Src/Scheduler/IssueQueue.sv
+++ b/Processor/Src/Scheduler/IssueQueue.sv
@@ -226,6 +226,7 @@ module IssueQueue (
                         recovery.toRecoveryPhase && recovery.notIssued[i],
                         recovery.flushRangeHeadPtr,
                         recovery.flushRangeTailPtr,
+                        recovery.flushAllInsns,
                         alPtrReg[i]
                         );
         end
@@ -236,6 +237,7 @@ module IssueQueue (
                             recovery.toRecoveryPhase,
                             recovery.flushRangeHeadPtr,
                             recovery.flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             port.writeAL_Ptr[i]
                             );
             end

--- a/Processor/Src/Scheduler/ReplayQueue.sv
+++ b/Processor/Src/Scheduler/ReplayQueue.sv
@@ -502,6 +502,7 @@ module ReplayQueue(
                             canBeFlushedEntryCount != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             replayEntryReg.intData[i].activeListPtr
                             );
             port.intReplayEntry[i] = replayEntryReg.intValid[i] && !flushInt[i];
@@ -513,6 +514,7 @@ module ReplayQueue(
                                 canBeFlushedEntryCount != 0,
                                 flushRangeHeadPtr,
                                 flushRangeTailPtr,
+                                recovery.flushAllInsns,
                                 replayEntryReg.complexData[i].activeListPtr
                                 );
             port.complexReplayEntry[i] = replayEntryReg.complexValid[i] && !flushComplex[i];
@@ -524,6 +526,7 @@ module ReplayQueue(
                             canBeFlushedEntryCount != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             replayEntryReg.memData[i].activeListPtr
                             );
             port.memReplayEntry[i] = replayEntryReg.memValid[i] && !flushMem[i];

--- a/Processor/Src/Scheduler/ReplayQueue.sv
+++ b/Processor/Src/Scheduler/ReplayQueue.sv
@@ -124,6 +124,7 @@ module ReplayQueue(
     ReplayQueueCountPath canBeFlushedEntryCount;    //FlushedOpが存在している可能性があるエントリの個数
     ActiveListIndexPath flushRangeHeadPtr;  //フラッシュされた命令の範囲のhead
     ActiveListIndexPath flushRangeTailPtr;  //フラッシュされた命令の範囲のtail
+    logic flushAllInsns;
     logic flushInt[ INT_ISSUE_WIDTH ];
     logic flushMem[ MEM_ISSUE_WIDTH ];
 `ifndef RSD_MARCH_UNIFIED_MULDIV_MEM_PIPE
@@ -502,7 +503,7 @@ module ReplayQueue(
                             canBeFlushedEntryCount != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
-                            recovery.flushAllInsns,
+                            flushAllInsns,
                             replayEntryReg.intData[i].activeListPtr
                             );
             port.intReplayEntry[i] = replayEntryReg.intValid[i] && !flushInt[i];
@@ -514,7 +515,7 @@ module ReplayQueue(
                                 canBeFlushedEntryCount != 0,
                                 flushRangeHeadPtr,
                                 flushRangeTailPtr,
-                                recovery.flushAllInsns,
+                                flushAllInsns,
                                 replayEntryReg.complexData[i].activeListPtr
                                 );
             port.complexReplayEntry[i] = replayEntryReg.complexValid[i] && !flushComplex[i];
@@ -526,7 +527,7 @@ module ReplayQueue(
                             canBeFlushedEntryCount != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
-                            recovery.flushAllInsns,
+                            flushAllInsns,
                             replayEntryReg.memData[i].activeListPtr
                             );
             port.memReplayEntry[i] = replayEntryReg.memValid[i] && !flushMem[i];
@@ -565,6 +566,7 @@ module ReplayQueue(
             canBeFlushedEntryCount <= count;
             flushRangeHeadPtr <= recovery.flushRangeHeadPtr;
             flushRangeTailPtr <= recovery.flushRangeTailPtr;
+            flushAllInsns <= recovery.flushAllInsns;
         end
         else if (canBeFlushedEntryCount > 0 && port.replay) begin
             canBeFlushedEntryCount <= canBeFlushedEntryCount - 1;

--- a/Processor/Src/Scheduler/WakeupPipelineRegister.sv
+++ b/Processor/Src/Scheduler/WakeupPipelineRegister.sv
@@ -179,6 +179,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountInt != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             intPipeReg[i][0].activeListPtr
                             );
             port.wakeup[i] = intPipeReg[i][0].valid && !flushInt[i];
@@ -192,6 +193,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountComplex != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             complexPipeReg[i][0].activeListPtr
                             );
             port.wakeup[(i+INT_ISSUE_WIDTH)] = complexPipeReg[i][0].valid && !flushComplex[i];
@@ -207,6 +209,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountMem != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             memPipeReg[i][0].activeListPtr
                           );
             port.wakeup[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)] = memPipeReg[i][0].valid && !flushMem[i];
@@ -227,6 +230,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountMem != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
+                            recovery.flushAllInsns,
                             memPipeReg[i][0].activeListPtr
                             );
             port.wakeup[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)] = memPipeReg[i][0].valid && !flushMem[i];


### PR DESCRIPTION
Fix recovery logic:
* flushAllInsns signal was added to distinguish whether ActiveList is empty or full. This signal is used to decide whether to flush the instruction.

Now recovery works correctly even when ActiveList is full.

(This bug was found using hardware fuzzing technique by mmxsrup)