### PR TITLE
renew the method of releasing MSHR entry when flush

### DIFF
--- a/Processor/Src/Cache/CacheSystemTypes.sv
+++ b/Processor/Src/Cache/CacheSystemTypes.sv
@@ -130,6 +130,9 @@ package CacheSystemTypes;
 
     } MSHR_Phase;
 
+    localparam ACTIVE_LIST_ENTRY_NUM = CONF_ACTIVE_LIST_ENTRY_NUM;
+    localparam ACTIVE_LIST_ENTRY_NUM_BIT_WIDTH = $clog2( ACTIVE_LIST_ENTRY_NUM );
+    typedef logic [ACTIVE_LIST_ENTRY_NUM_BIT_WIDTH-1:0] ActiveListIndexPath;
     typedef struct packed   // MissStatusHandlingRegister;
     {
         logic valid;
@@ -170,6 +173,9 @@ package CacheSystemTypes;
 
         // For flush
         DCacheIndexPath flushIndex;
+
+        // AL Ptr info to release MSHR entry when allocator load is flushed
+         ActiveListIndexPath activeListPtr;
     } MissStatusHandlingRegister;
 
     typedef struct packed   // DCachePortMultiplexerIn

--- a/Processor/Src/Cache/DCache.sv
+++ b/Processor/Src/Cache/DCache.sv
@@ -1431,6 +1431,8 @@ module DCacheMissHandler(
 
             // For flush
             mshrFlushComplete[i] = FALSE;
+            // For data merging
+            mergedLine[i] = '0;
 
             case(mshr[i].phase)
                 default: begin

--- a/Processor/Src/Cache/DCacheIF.sv
+++ b/Processor/Src/Cache/DCacheIF.sv
@@ -98,6 +98,7 @@ input
     // Miss handler
     logic initMSHR[MSHR_NUM];
     PhyAddrPath initMSHR_Addr[MSHR_NUM];
+    ActiveListIndexPath initMSHR_ActiveListPtr[MSHR_NUM];
 
     logic mshrValid[MSHR_NUM];
     PhyAddrPath mshrAddr[MSHR_NUM];
@@ -111,17 +112,8 @@ input
 
     logic isUncachable[MSHR_NUM];
 
-    // MSHRをAllocateしたLoad命令がMemoryRegisterReadStageでflushされた場合，AllocateされたMSHRは解放可能になる
-    logic makeMSHRCanBeInvalidByMemoryRegisterReadStage[MSHR_NUM];
-
-    // MSHRをAllocateしたLoad命令がMemoryExecutionStageでflushされた場合，AllocateされたMSHRは解放可能になる
-    logic makeMSHRCanBeInvalidByMemoryExecutionStage[MSHR_NUM];
-    
     // MSHRをAllocateしたLoad命令がStoreForwardingによって完了した場合，AllocateされたMSHRは解放可能になる
     logic makeMSHRCanBeInvalidByMemoryTagAccessStage[MSHR_NUM];
-
-    // MSHRをAllocateしたLoad命令がReplayQueueの先頭でflushされた場合，AllocateされたMSHRは解放可能になる
-    logic makeMSHRCanBeInvalidByReplayQueue[MSHR_NUM];
 
     VectorPath storedLineData;
     logic [DCACHE_LINE_BYTE_NUM-1:0] storedLineByteWE;
@@ -237,6 +229,7 @@ input
         rst,
         initMSHR,
         initMSHR_Addr,
+        initMSHR_ActiveListPtr,
         mshrCacheGrt,
         mshrCacheMuxTagOut,
         mshrCacheMuxDataOut,
@@ -247,10 +240,7 @@ input
         mshrCanBeInvalid,
         isAllocatedByStore,
         isUncachable,
-        makeMSHRCanBeInvalidByMemoryRegisterReadStage,
-        makeMSHRCanBeInvalidByMemoryExecutionStage,
         makeMSHRCanBeInvalidByMemoryTagAccessStage,
-        makeMSHRCanBeInvalidByReplayQueue,
         storedLineData,
         storedLineByteWE,
         dcFlushing,
@@ -324,12 +314,10 @@ input
         memAccessResponse,
         initMSHR,
         initMSHR_Addr,
+        initMSHR_ActiveListPtr,
         isAllocatedByStore,
         isUncachable,
-        makeMSHRCanBeInvalidByMemoryRegisterReadStage,
-        makeMSHRCanBeInvalidByMemoryExecutionStage,
         makeMSHRCanBeInvalidByMemoryTagAccessStage,
-        makeMSHRCanBeInvalidByReplayQueue,
         storedLineData,
         storedLineByteWE,
         dcFlushReq,

--- a/Processor/Src/Cache/DCacheIF.sv
+++ b/Processor/Src/Cache/DCacheIF.sv
@@ -114,6 +114,9 @@ input
     // MSHRをAllocateしたLoad命令がMemoryRegisterReadStageでflushされた場合，AllocateされたMSHRは解放可能になる
     logic makeMSHRCanBeInvalidByMemoryRegisterReadStage[MSHR_NUM];
 
+    // MSHRをAllocateしたLoad命令がMemoryExecutionStageでflushされた場合，AllocateされたMSHRは解放可能になる
+    logic makeMSHRCanBeInvalidByMemoryExecutionStage[MSHR_NUM];
+    
     // MSHRをAllocateしたLoad命令がStoreForwardingによって完了した場合，AllocateされたMSHRは解放可能になる
     logic makeMSHRCanBeInvalidByMemoryTagAccessStage[MSHR_NUM];
 
@@ -245,6 +248,7 @@ input
         isAllocatedByStore,
         isUncachable,
         makeMSHRCanBeInvalidByMemoryRegisterReadStage,
+        makeMSHRCanBeInvalidByMemoryExecutionStage,
         makeMSHRCanBeInvalidByMemoryTagAccessStage,
         makeMSHRCanBeInvalidByReplayQueue,
         storedLineData,
@@ -323,6 +327,7 @@ input
         isAllocatedByStore,
         isUncachable,
         makeMSHRCanBeInvalidByMemoryRegisterReadStage,
+        makeMSHRCanBeInvalidByMemoryExecutionStage,
         makeMSHRCanBeInvalidByMemoryTagAccessStage,
         makeMSHRCanBeInvalidByReplayQueue,
         storedLineData,

--- a/Processor/Src/Core.sv
+++ b/Processor/Src/Core.sv
@@ -172,7 +172,7 @@ output
         MulDivUnit mulDivUnit(mulDivUnitIF);
 
     MemoryIssueStage memIsStage( memIsStageIF, scStageIF, schedulerIF, recoveryManagerIF, mulDivUnitIF, ctrlIF, debugIF );
-    MemoryRegisterReadStage memRrStage( memRrStageIF, memIsStageIF,loadStoreUnitIF, mulDivUnitIF, registerFileIF, bypassNetworkIF, recoveryManagerIF, ctrlIF, debugIF );
+    MemoryRegisterReadStage memRrStage( memRrStageIF, memIsStageIF, mulDivUnitIF, registerFileIF, bypassNetworkIF, recoveryManagerIF, ctrlIF, debugIF );
     MemoryExecutionStage memExStage( memExStageIF, memRrStageIF, loadStoreUnitIF, cacheFlushManagerIF, mulDivUnitIF, bypassNetworkIF, recoveryManagerIF, ctrlIF, csrUnitIF, debugIF );
     MemoryTagAccessStage mtStage( mtStageIF, memExStageIF, schedulerIF, loadStoreUnitIF, mulDivUnitIF, recoveryManagerIF, ctrlIF, debugIF, perfCounterIF );
     MemoryAccessStage maStage( maStageIF, mtStageIF, loadStoreUnitIF, mulDivUnitIF, bypassNetworkIF, ioUnitIF, recoveryManagerIF, ctrlIF, debugIF );
@@ -180,7 +180,7 @@ output
         LoadQueue loadQueue( loadStoreUnitIF, recoveryManagerIF );
         StoreQueue storeQueue( loadStoreUnitIF, recoveryManagerIF );
         StoreCommitter storeCommitter(loadStoreUnitIF, recoveryManagerIF, ioUnitIF, debugIF, perfCounterIF);
-        DCache dCache( loadStoreUnitIF, cacheSystemIF, ctrlIF );
+        DCache dCache( loadStoreUnitIF, cacheSystemIF, ctrlIF, recoveryManagerIF);
     MemoryRegisterWriteStage memRwStage( /*memRwStageIF,*/ maStageIF, registerFileIF, activeListIF, recoveryManagerIF, ctrlIF, debugIF );
 
     RegisterFile registerFile( registerFileIF );

--- a/Processor/Src/ExecUnit/IntALU.sv
+++ b/Processor/Src/ExecUnit/IntALU.sv
@@ -106,6 +106,8 @@ module IntALU(
         
         opA     = fuOpA_In;
         opB     = fuOpB_In;
+        signedOpA = '0;
+        signedOpB = '0;
         
         case( aluCode )
             // AND  論理積

--- a/Processor/Src/LoadStoreUnit/LoadStoreUnitIF.sv
+++ b/Processor/Src/LoadStoreUnit/LoadStoreUnitIF.sv
@@ -29,6 +29,7 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
     logic executeLoad [ LOAD_ISSUE_WIDTH ];
     logic executedLoadRegValid [LOAD_ISSUE_WIDTH];
     PhyAddrPath executedLoadAddr [ LOAD_ISSUE_WIDTH ];
+    MemoryMapType executedLoadMemMapType [ LOAD_ISSUE_WIDTH ];
     DataPath executedLoadData [ LOAD_ISSUE_WIDTH ];
     PC_Path executedLoadPC  [LOAD_ISSUE_WIDTH ];
     VectorPath executedLoadVectorData [ LOAD_ISSUE_WIDTH ];
@@ -125,6 +126,9 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
 
     // そのリクエストがアクセスに成功した場合，AllocateされたMSHRは解放可能になる
     logic makeMSHRCanBeInvalid[LOAD_ISSUE_WIDTH];
+    
+    // MSHRをAllocateしたLoad命令がMemoryExecutionStageでflushされた場合，AllocateされたMSHRは解放可能になる
+    logic makeMSHRCanBeInvalidByMemoryExecutionStage[MSHR_NUM];
 
     // MSHRをAllocateしたLoad命令がStoreForwardingによって完了した場合，AllocateされたMSHRは解放可能になる
     logic makeMSHRCanBeInvalidByMemoryTagAccessStage[MSHR_NUM];
@@ -158,6 +162,7 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
         dcReadCancelFromMT_Stage,
         makeMSHRCanBeInvalidByMemoryRegisterReadStage,
         makeMSHRCanBeInvalid,
+        makeMSHRCanBeInvalidByMemoryExecutionStage,
         makeMSHRCanBeInvalidByMemoryTagAccessStage,
         makeMSHRCanBeInvalidByReplayQueue,
     output
@@ -213,6 +218,7 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
         allocateStoreQueue,
         executeLoad,
         executedLoadAddr,
+        executedLoadMemMapType,
         executeStore,
         executedStoreQueuePtrByLoad,
         executedStoreQueuePtrByStore,
@@ -319,7 +325,8 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
         dcReadReq,
         dcReadAddr,
         dcReadUncachable,
-        makeMSHRCanBeInvalid
+        makeMSHRCanBeInvalid,
+        makeMSHRCanBeInvalidByMemoryExecutionStage
     );
 
     modport MemoryTagAccessStage(
@@ -339,6 +346,7 @@ interface LoadStoreUnitIF( input logic clk, rst, rstStart );
         executedLoadQueuePtrByLoad,
         executedLoadQueuePtrByStore,
         executedLoadAddr,
+        executedLoadMemMapType,
         executedLoadPC,
         executedLoadRegValid,
         executeStore,

--- a/Processor/Src/LoadStoreUnit/StoreQueue.sv
+++ b/Processor/Src/LoadStoreUnit/StoreQueue.sv
@@ -297,6 +297,7 @@ module StoreQueue(
             for (int j = 0; j < STORE_QUEUE_ENTRY_NUM; j++) begin
                 addrMatch[i][j] =
                     storeQueue[j].finished &&
+                    port.executedLoadMemMapType[i] != MMT_ILLEGAL && 
                     storeQueue[j].address == LSQ_ToBlockAddr(port.executedLoadAddr[i]) &&
                     ((storeQueue[j].wordWE & executedLoadWordRE[i]) != '0) &&
                     ((storeQueue[j].byteWE & executedLoadByteRE[i]) != '0);

--- a/Processor/Src/Pipeline/MemoryBackEnd/MemoryTagAccessStage.sv
+++ b/Processor/Src/Pipeline/MemoryBackEnd/MemoryTagAccessStage.sv
@@ -132,6 +132,7 @@ module MemoryTagAccessStage(
             // Load store unit
             loadStoreUnit.executeLoad[i] = ldUpdate[i] && isLoad[i];
             loadStoreUnit.executedLoadAddr[i] = ldPipeReg[i].phyAddrOut;
+            loadStoreUnit.executedLoadMemMapType[i] = ldPipeReg[i].memMapType;
             loadStoreUnit.executedLoadPC[i] = ldIqData[i].pc;
             loadStoreUnit.executedLoadMemAccessMode[i] = ldIqData[i].memOpInfo.memAccessMode;
             loadStoreUnit.executedStoreQueuePtrByLoad[i] = ldIqData[i].memOpInfo.storeQueuePtr;

--- a/Processor/Src/Recovery/RecoveryManagerIF.sv
+++ b/Processor/Src/Recovery/RecoveryManagerIF.sv
@@ -246,6 +246,17 @@ interface RecoveryManagerIF( input logic clk, rst );
         toRecoveryPhase
     );
 
+     modport DCache(
+    input
+        toRecoveryPhase
+    );
+
+    modport DCacheMissHandler(
+    input
+        toRecoveryPhase,
+        flushRangeHeadPtr,
+        flushRangeTailPtr
+    );
 
     modport IntegerIssueStage(
     input

--- a/Processor/Src/RenameLogic/RenameLogicCommitter.sv
+++ b/Processor/Src/RenameLogic/RenameLogicCommitter.sv
@@ -105,6 +105,8 @@ module RenameLogicCommitter(
 
         // The head and tail entries of an active list.
         alReadData = activeList.readData;
+        releaseNum = '0;
+        flushNum = '0;
 
         // Update control signals for the active list and the free lists in
         //  a rename logic.
@@ -138,7 +140,7 @@ module RenameLogicCommitter(
             end
 
             recovery.inRecoveryAL = FALSE;
-            flushNum = 0;
+            flushNum = '0;
         end
         else if(phase == PHASE_RECOVER_0) begin
             activeList.popHeadNum = 0;
@@ -148,7 +150,7 @@ module RenameLogicCommitter(
                 nextReleasedReg[i].phyReleasedReg = 0;
             end
             recovery.inRecoveryAL = TRUE;
-            flushNum = 0;
+            flushNum = '0;
         end
         else begin
 

--- a/Processor/Src/SysDeps/Verilator/TestMain.cpp
+++ b/Processor/Src/SysDeps/Verilator/TestMain.cpp
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
     // To access the module generated in generate,
     // use (Label given in generate section)__DOT__(module name)
     size_t mainMemWordSize = sizeof(top->Main_Zynq_Wrapper->main->memory->body->body__DOT__ram->array) / sizeof(uint32_t);
-    uint32_t* mainMem = (uint32_t*)(top->Main_Zynq_Wrapper->main->memory->body->body__DOT__ram->array);
+    uint32_t* mainMem = reinterpret_cast<uint32_t*>(&top->Main_Zynq_Wrapper->main->memory->body->body__DOT__ram->array);
 
     // Fill dummy data
     for (int i = 0; i < mainMemWordSize; i++) {


### PR DESCRIPTION
[old]
Instructions record the allocated MSHR entry ID, and when they're flushed, send a flush signal from each backend stage to MSHR.

[new]
MSHR entries record the AL entry ID of its allocator load instruction, and when the instruction is flushed, MSHR entries directly  flush itself.