### PR TITLE
Fix wakeup pipeline register

### DIFF
--- a/Processor/Src/Scheduler/WakeupPipelineRegister.sv
+++ b/Processor/Src/Scheduler/WakeupPipelineRegister.sv
@@ -47,6 +47,7 @@ module WakeupPipelineRegister(
     logic [$clog2(ISSUE_QUEUE_MEM_LATENCY):0] canBeFlushedRegCountMem;    //FlushedOpが存在している可能性があるMemパイプラインレジスタの段数
     ActiveListIndexPath flushRangeHeadPtr;  //フラッシュされた命令の範囲のhead
     ActiveListIndexPath flushRangeTailPtr;  //フラッシュされた命令の範囲のtail
+    logic flushAllInsns;
     logic flushInt[ INT_ISSUE_WIDTH ];
     logic flushMem[ LOAD_ISSUE_WIDTH ];
     IssueQueueIndexPath intSelectedPtr[ INT_ISSUE_WIDTH ];
@@ -207,7 +208,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountInt != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
-                            recovery.flushAllInsns,
+                            flushAllInsns,
                             intPipeReg[i][0].activeListPtr
                             );
             if (ISSUE_QUEUE_INT_LATENCY == 1 ) begin
@@ -231,7 +232,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountComplex != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
-                            recovery.flushAllInsns,
+                            flushAllInsns,
                             complexPipeReg[i][0].activeListPtr
                             );
             port.wakeup[(i+INT_ISSUE_WIDTH)] = complexPipeReg[i][0].valid && !flushComplex[i];
@@ -247,7 +248,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountMem != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
-                            recovery.flushAllInsns,
+                            flushAllInsns,
                             memPipeReg[i][0].activeListPtr
                           );
             port.wakeup[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)] = memPipeReg[i][0].valid && !flushMem[i];
@@ -268,7 +269,7 @@ module WakeupPipelineRegister(
                             canBeFlushedRegCountMem != 0,
                             flushRangeHeadPtr,
                             flushRangeTailPtr,
-                            recovery.flushAllInsns,
+                            flushAllInsns,
                             memPipeReg[i][0].activeListPtr
                             );
             port.wakeup[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)] = memPipeReg[i][0].valid && !flushMem[i];
@@ -321,6 +322,7 @@ module WakeupPipelineRegister(
             canBeFlushedRegCountMem <= 0;
             flushRangeHeadPtr <= 0;
             flushRangeTailPtr <= 0;
+            flushAllInsns <= FALSE;
         end
         else if(recovery.toRecoveryPhase && recovery.recoveryFromRwStage) begin
             canBeFlushedRegCountInt <= ISSUE_QUEUE_INT_LATENCY;
@@ -330,6 +332,7 @@ module WakeupPipelineRegister(
             canBeFlushedRegCountMem <= ISSUE_QUEUE_MEM_LATENCY;
             flushRangeHeadPtr <= recovery.flushRangeHeadPtr;
             flushRangeTailPtr <= recovery.flushRangeTailPtr;
+            flushAllInsns <= recovery.flushAllInsns;
         end
         else begin
             if(canBeFlushedRegCountInt == ISSUE_QUEUE_INT_LATENCY) begin

--- a/Processor/Src/Scheduler/WakeupPipelineRegister.sv
+++ b/Processor/Src/Scheduler/WakeupPipelineRegister.sv
@@ -140,6 +140,7 @@ module WakeupPipelineRegister(
                         intPipeReg[i][j-1] <= intPipeReg[i][j];
                     end
                     intPipeReg[i][ ISSUE_QUEUE_INT_LATENCY-2 ].valid <= FALSE;
+                    intPipeReg[i][ ISSUE_QUEUE_INT_LATENCY-2 ].depVector <= '0;
                 end
             end
 `ifndef RSD_MARCH_UNIFIED_MULDIV_MEM_PIPE
@@ -148,6 +149,7 @@ module WakeupPipelineRegister(
                     complexPipeReg[i][j-1] <= complexPipeReg[i][j];
                 end
                 complexPipeReg[i][ ISSUE_QUEUE_COMPLEX_LATENCY-2 ].valid <= FALSE;
+                complexPipeReg[i][ ISSUE_QUEUE_COMPLEX_LATENCY-2 ].depVector <= '0;
             end
 `endif
 
@@ -156,6 +158,7 @@ module WakeupPipelineRegister(
                     memPipeReg[i][j-1] <= memPipeReg[i][j];
                 end
                 memPipeReg[i][ ISSUE_QUEUE_MEM_LATENCY-2 ].valid <= FALSE;
+                memPipeReg[i][ ISSUE_QUEUE_MEM_LATENCY-2 ].depVector <= '0;
             end
         end
     end
@@ -329,15 +332,30 @@ module WakeupPipelineRegister(
             flushRangeTailPtr <= recovery.flushRangeTailPtr;
         end
         else begin
-            if(canBeFlushedRegCountInt>0 && !port.stall) begin
+            if(canBeFlushedRegCountInt == ISSUE_QUEUE_INT_LATENCY) begin
+                if(!port.stall) begin
+                    canBeFlushedRegCountInt <= canBeFlushedRegCountInt-1;
+                end
+            end
+            else if (canBeFlushedRegCountInt > 0) begin
                 canBeFlushedRegCountInt <= canBeFlushedRegCountInt-1;
             end
 `ifndef RSD_MARCH_UNIFIED_MULDIV_MEM_PIPE
-            if(canBeFlushedRegCountComplex>0 && !port.stall) begin
+            if(canBeFlushedRegCountComplex == ISSUE_QUEUE_COMPLEX_LATENCY) begin
+                if(!port.stall) begin
+                    canBeFlushedRegCountComplex <= canBeFlushedRegCountComplex-1;
+                end
+            end
+            else if (canBeFlushedRegCountComplex > 0) begin
                 canBeFlushedRegCountComplex <= canBeFlushedRegCountComplex-1;
             end
 `endif
-            if(canBeFlushedRegCountMem>0 && !port.stall) begin
+            if(canBeFlushedRegCountMem == ISSUE_QUEUE_MEM_LATENCY) begin
+                if(!port.stall) begin
+                    canBeFlushedRegCountMem <= canBeFlushedRegCountMem-1;
+                end
+            end
+            else if (canBeFlushedRegCountMem > 0) begin
                 canBeFlushedRegCountMem <= canBeFlushedRegCountMem-1;
             end
         end


### PR DESCRIPTION
fix a bug of WakeupPipelineRegister
- correctly update wakeupVector and canBeFlushedRegCount when stall.
- selectively flush by using flushAllInsns instead of recovery.flushAllInsns