### PR TITLE
fix: fix a bug concerning the update of the wakeupVector in WakeupPip…

### DIFF
--- a/Processor/Src/Recovery/RecoveryManagerIF.sv
+++ b/Processor/Src/Recovery/RecoveryManagerIF.sv
@@ -203,8 +203,6 @@ interface RecoveryManagerIF( input logic clk, rst );
     );
 
     modport SelectLogic(
-    input
-        flushIQ_Entry,
     output
         selected,
         selectedPtr

--- a/Processor/Src/Recovery/RecoveryManagerIF.sv
+++ b/Processor/Src/Recovery/RecoveryManagerIF.sv
@@ -203,6 +203,8 @@ interface RecoveryManagerIF( input logic clk, rst );
     );
 
     modport SelectLogic(
+    input
+        flushIQ_Entry,
     output
         selected,
         selectedPtr

--- a/Processor/Src/Scheduler/SelectLogic.sv
+++ b/Processor/Src/Scheduler/SelectLogic.sv
@@ -60,6 +60,7 @@ module SelectLogic(
     // For Recovery Maneger IF
     logic recoverySelected [ ISSUE_WIDTH ];
     IssueQueueIndexPath recoverySelectedPtr [ ISSUE_WIDTH ];
+    IssueQueueOneHotPath flushIQ_Entry;
 
     // Requests are interleaved.
     // ex. ENTRY_NUM = 4, GRANT_NUM = 2 case:
@@ -141,6 +142,7 @@ module SelectLogic(
 `endif
 
     always_comb begin
+        flushIQ_Entry = recovery.flushIQ_Entry;
 
         for (int i = 0; i < ISSUE_QUEUE_ENTRY_NUM; i++) begin
             intRequest[i] = port.opReady[i] && port.intIssueReq[i];
@@ -163,7 +165,7 @@ module SelectLogic(
         for (int i = 0; i < INT_ISSUE_WIDTH; i++) begin
             portSelected[i] = intSelected[i];
             portSelectedPtr[i] = intSelectedPtr[i];
-            portSelectedVector[i] = intGrant;
+            portSelectedVector[i] = intGrant & ~flushIQ_Entry;
             recoverySelected[i] = intSelected[i];
             recoverySelectedPtr[i] = intSelectedPtr[i];
         end
@@ -172,7 +174,7 @@ module SelectLogic(
         for (int i = 0; i < COMPLEX_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH] = compSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH] = compSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH] = compGrant;
+            portSelectedVector[i+INT_ISSUE_WIDTH] = compGrant & ~flushIQ_Entry;
             recoverySelected[i+INT_ISSUE_WIDTH] = compSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH] = compSelectedPtr[i];
         end
@@ -182,7 +184,7 @@ module SelectLogic(
         for (int i = 0; i < MEM_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memGrant;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memGrant & ~flushIQ_Entry;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelectedPtr[i];
         end
@@ -190,14 +192,14 @@ module SelectLogic(
         for (int i = 0; i < LOAD_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadGrant;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadGrant & ~flushIQ_Entry;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelectedPtr[i];
         end
         for (int i = 0; i < STORE_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeGrant;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeGrant & ~flushIQ_Entry;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelectedPtr[i];
         end
@@ -207,7 +209,7 @@ module SelectLogic(
         for (int i = 0; i < FP_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpGrant;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpGrant & ~flushIQ_Entry;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelectedPtr[i];
         end

--- a/Processor/Src/Scheduler/SelectLogic.sv
+++ b/Processor/Src/Scheduler/SelectLogic.sv
@@ -60,7 +60,6 @@ module SelectLogic(
     // For Recovery Maneger IF
     logic recoverySelected [ ISSUE_WIDTH ];
     IssueQueueIndexPath recoverySelectedPtr [ ISSUE_WIDTH ];
-    IssueQueueOneHotPath flushIQ_Entry;
 
     // Requests are interleaved.
     // ex. ENTRY_NUM = 4, GRANT_NUM = 2 case:
@@ -142,8 +141,6 @@ module SelectLogic(
 `endif
 
     always_comb begin
-        flushIQ_Entry = recovery.flushIQ_Entry;
-
         for (int i = 0; i < ISSUE_QUEUE_ENTRY_NUM; i++) begin
             intRequest[i] = port.opReady[i] && port.intIssueReq[i];
             `ifdef RSD_MARCH_UNIFIED_LDST_MEM_PIPE
@@ -165,7 +162,7 @@ module SelectLogic(
         for (int i = 0; i < INT_ISSUE_WIDTH; i++) begin
             portSelected[i] = intSelected[i];
             portSelectedPtr[i] = intSelectedPtr[i];
-            portSelectedVector[i] = intGrant & ~flushIQ_Entry;
+            portSelectedVector[i] = intGrant;
             recoverySelected[i] = intSelected[i];
             recoverySelectedPtr[i] = intSelectedPtr[i];
         end
@@ -174,7 +171,7 @@ module SelectLogic(
         for (int i = 0; i < COMPLEX_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH] = compSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH] = compSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH] = compGrant & ~flushIQ_Entry;
+            portSelectedVector[i+INT_ISSUE_WIDTH] = compGrant;
             recoverySelected[i+INT_ISSUE_WIDTH] = compSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH] = compSelectedPtr[i];
         end
@@ -184,7 +181,7 @@ module SelectLogic(
         for (int i = 0; i < MEM_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memGrant & ~flushIQ_Entry;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memGrant;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = memSelectedPtr[i];
         end
@@ -192,14 +189,14 @@ module SelectLogic(
         for (int i = 0; i < LOAD_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadGrant & ~flushIQ_Entry;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadGrant;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH] = loadSelectedPtr[i];
         end
         for (int i = 0; i < STORE_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeGrant & ~flushIQ_Entry;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeGrant;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+LOAD_ISSUE_WIDTH] = storeSelectedPtr[i];
         end
@@ -209,7 +206,7 @@ module SelectLogic(
         for (int i = 0; i < FP_ISSUE_WIDTH; i++) begin
             portSelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelected[i];
             portSelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelectedPtr[i];
-            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpGrant & ~flushIQ_Entry;
+            portSelectedVector[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpGrant;
             recoverySelected[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelected[i];
             recoverySelectedPtr[i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH] = fpSelectedPtr[i];
         end

--- a/Processor/Src/Scheduler/WakeupPipelineRegister.sv
+++ b/Processor/Src/Scheduler/WakeupPipelineRegister.sv
@@ -121,6 +121,7 @@ module WakeupPipelineRegister(
             for( int i = 0; i < INT_ISSUE_WIDTH; i++ ) begin
                 for( int j = 0; j < ISSUE_QUEUE_INT_LATENCY; j++ ) begin
                     intPipeReg[i][j].valid <= FALSE;
+                    intPipeReg[i][j].depVector <= '0;
                 end
             end
 
@@ -128,6 +129,7 @@ module WakeupPipelineRegister(
             for( int i = 0; i < COMPLEX_ISSUE_WIDTH; i++ ) begin
                 for( int j = 0; j < ISSUE_QUEUE_COMPLEX_LATENCY; j++ ) begin
                     complexPipeReg[i][j].valid <= FALSE;
+                    complexPipeReg[i][j].depVector <= '0;
                 end
             end
 `endif
@@ -135,6 +137,7 @@ module WakeupPipelineRegister(
             for( int i = 0; i < MEM_ISSUE_WIDTH; i++ ) begin
                 for( int j = 0; j < ISSUE_QUEUE_MEM_LATENCY; j++ ) begin
                     memPipeReg[i][j].valid <= FALSE;
+                    memPipeReg[i][j].depVector <= '0;
                 end
             end
 
@@ -142,6 +145,7 @@ module WakeupPipelineRegister(
             for( int i = 0; i < FP_ISSUE_WIDTH; i++ ) begin
                 for( int j = 0; j < ISSUE_QUEUE_FP_LATENCY; j++ ) begin
                     fpPipeReg[i][j].valid <= FALSE;
+                    fpPipeReg[i][j].depVector <= '0;
                 end
             end
 `endif

--- a/Processor/Src/Scheduler/WakeupPipelineRegister.sv
+++ b/Processor/Src/Scheduler/WakeupPipelineRegister.sv
@@ -116,8 +116,8 @@ module WakeupPipelineRegister(
 
     always_ff @( posedge port.clk ) begin
         if( port.rst ||(recovery.toRecoveryPhase && !recovery.recoveryFromRwStage) ) begin
-            // パイプラインレジスタの初期化
-            // Don't care except valid bits.
+            // Upon reset or recovery from the commit stage, initialize the wakeup pipeline register.
+            // Set the valid flag to FALSE and the depVector to '0 to prevent incorrect wakeups of unrelated registers/instructions.
             for( int i = 0; i < INT_ISSUE_WIDTH; i++ ) begin
                 for( int j = 0; j < ISSUE_QUEUE_INT_LATENCY; j++ ) begin
                     intPipeReg[i][j].valid <= FALSE;
@@ -221,6 +221,8 @@ module WakeupPipelineRegister(
 
 
     always_comb begin
+        // A bit vector indicating whether each IQ entry is flushed.
+        // This is used to deassert the wakeup signal of instructions that are selected but flushed at the same time.
         flushIQ_Entry = recovery.flushIQ_Entry;
         //
         // Register selected ops.

--- a/Processor/Src/Scheduler/WakeupPipelineRegister.sv
+++ b/Processor/Src/Scheduler/WakeupPipelineRegister.sv
@@ -227,7 +227,7 @@ module WakeupPipelineRegister(
         //
         // Register selected ops.
         //
-        for ( int i = 0; i < INT_ISSUE_WIDTH; i++ ) begin
+        for (int i = 0; i < INT_ISSUE_WIDTH; i++ ) begin
             // Input of PipeReg (Selected Data)
             intSelectedPtr[i] = port.selectedPtr[i];
             nextIntPipeReg[i].valid = port.selected[i] && !flushIQ_Entry[intSelectedPtr[i]];
@@ -267,7 +267,7 @@ module WakeupPipelineRegister(
         //
         // Exit from the pipeline registers and now wakeup consumers.
         //
-        for ( int i = 0; i < INT_ISSUE_WIDTH; i++ ) begin
+        for (int i = 0; i < INT_ISSUE_WIDTH; i++ ) begin
             // Output of PipeReg (Wakeup Data)
             // Now, WAKEUP_WIDTH == ISSUE_WIDTH
             flushInt[i] = SelectiveFlushDetector(
@@ -369,7 +369,7 @@ module WakeupPipelineRegister(
             port.releasePtr[i] = intPipeReg[i][0].ptr;
         end
 `ifndef RSD_MARCH_UNIFIED_MULDIV_MEM_PIPE
-        for ( int i = 0; i < COMPLEX_ISSUE_WIDTH; i++) begin
+        for (int i = 0; i < COMPLEX_ISSUE_WIDTH; i++) begin
             port.releaseEntry[(i+INT_ISSUE_WIDTH)] = complexPipeReg[i][0].valid;
             port.releasePtr[(i+INT_ISSUE_WIDTH)] = complexPipeReg[i][0].ptr;
         end
@@ -379,7 +379,7 @@ module WakeupPipelineRegister(
             port.releasePtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)] = memPipeReg[i][0].ptr;
         end
 `ifdef RSD_MARCH_FP_PIPE
-        for ( int i = 0; i < FP_ISSUE_WIDTH; i++) begin
+        for (int i = 0; i < FP_ISSUE_WIDTH; i++) begin
             port.releaseEntry[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)] = fpPipeReg[i][0].valid;
             port.releasePtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)] = fpPipeReg[i][0].ptr;
         end

--- a/Processor/Src/Scheduler/WakeupPipelineRegister.sv
+++ b/Processor/Src/Scheduler/WakeupPipelineRegister.sv
@@ -230,7 +230,7 @@ module WakeupPipelineRegister(
             intSelectedPtr[i] = port.selectedPtr[i];
             nextIntPipeReg[i].valid = port.selected[i] && !flushIQ_Entry[intSelectedPtr[i]];
             nextIntPipeReg[i].ptr = port.selectedPtr[i];
-            nextIntPipeReg[i].depVector = port.selectedVector[i];
+            nextIntPipeReg[i].depVector = port.selectedVector[i] & ~flushIQ_Entry;
             nextIntPipeReg[i].activeListPtr = recovery.selectedActiveListPtr[i];
         end
 
@@ -239,7 +239,7 @@ module WakeupPipelineRegister(
             complexSelectedPtr[i] = port.selectedPtr[(i+INT_ISSUE_WIDTH)];
             nextComplexPipeReg[i].valid = port.selected[(i+INT_ISSUE_WIDTH)] && !flushIQ_Entry[complexSelectedPtr[i]];
             nextComplexPipeReg[i].ptr = port.selectedPtr[(i+INT_ISSUE_WIDTH)];
-            nextComplexPipeReg[i].depVector = port.selectedVector[(i+INT_ISSUE_WIDTH)];
+            nextComplexPipeReg[i].depVector = port.selectedVector[(i+INT_ISSUE_WIDTH)] & ~flushIQ_Entry;
             nextComplexPipeReg[i].activeListPtr = recovery.selectedActiveListPtr[(i+INT_ISSUE_WIDTH)];
         end
 `endif
@@ -248,7 +248,7 @@ module WakeupPipelineRegister(
             memSelectedPtr[i] = port.selectedPtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)];
             nextMemPipeReg[i].valid = port.selected[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)] && !flushIQ_Entry[memSelectedPtr[i]];
             nextMemPipeReg[i].ptr = port.selectedPtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)];
-            nextMemPipeReg[i].depVector = port.selectedVector[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)];
+            nextMemPipeReg[i].depVector = port.selectedVector[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)] & ~flushIQ_Entry;
             nextMemPipeReg[i].activeListPtr = recovery.selectedActiveListPtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH)];
         end
 
@@ -257,7 +257,7 @@ module WakeupPipelineRegister(
             fpSelectedPtr[i] = port.selectedPtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)];
             nextFPPipeReg[i].valid = port.selected[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)] && !flushIQ_Entry[fpSelectedPtr[i]];
             nextFPPipeReg[i].ptr = port.selectedPtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)];
-            nextFPPipeReg[i].depVector = port.selectedVector[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)];
+            nextFPPipeReg[i].depVector = port.selectedVector[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)] & ~flushIQ_Entry;
             nextFPPipeReg[i].activeListPtr = recovery.selectedActiveListPtr[(i+INT_ISSUE_WIDTH+COMPLEX_ISSUE_WIDTH+MEM_ISSUE_WIDTH)];
         end
 `endif


### PR DESCRIPTION
fix a bug concerning the wakeupVector in WakeupPipelineRegister

- On a pipeline flush in the commit stage, the wakeupVector must be reset to 0 to prevent incorrectly waking up unrelated instructions.
- The wakeupVector of instructions that are selected in the scheduler but flushed at the same time must be deasserted.