### PR TITLE
fix: fix bugs about the reset of divider on pipeline flush

### DIFF
--- a/Processor/Src/FloatingPointUnit/FPDivSqrtUnit.sv
+++ b/Processor/Src/FloatingPointUnit/FPDivSqrtUnit.sv
@@ -26,7 +26,7 @@ module FPDivSqrtUnit(FPDivSqrtUnitIF.FPDivSqrtUnit port, RecoveryManagerIF.FPDiv
     for (genvar i = 0; i < FP_DIVSQRT_ISSUE_WIDTH; i++) begin : BlockDivUnit
         FP32DivSqrter fpDivSqrter(
             .clk(port.clk),
-            .rst(port.rst),
+            .rst(port.rst | flush[i]),
             .lhs(port.dataInA[i]),
             .rhs(port.dataInB[i]),
             .is_divide(port.is_divide[i]),

--- a/Processor/Src/FloatingPointUnit/FPDivSqrtUnit.sv
+++ b/Processor/Src/FloatingPointUnit/FPDivSqrtUnit.sv
@@ -20,13 +20,14 @@ module FPDivSqrtUnit(FPDivSqrtUnitIF.FPDivSqrtUnit port, RecoveryManagerIF.FPDiv
     logic finished[FP_DIVSQRT_ISSUE_WIDTH];
 
     logic flush[FP_DIVSQRT_ISSUE_WIDTH];
+    logic rst_divider[FP_DIVSQRT_ISSUE_WIDTH];
     ActiveListIndexPath regActiveListPtr[FP_DIVSQRT_ISSUE_WIDTH];
     ActiveListIndexPath nextActiveListPtr[FP_DIVSQRT_ISSUE_WIDTH];
 
     for (genvar i = 0; i < FP_DIVSQRT_ISSUE_WIDTH; i++) begin : BlockDivUnit
         FP32DivSqrter fpDivSqrter(
             .clk(port.clk),
-            .rst(port.rst | flush[i]),
+            .rst(rst_divider[i]),
             .lhs(port.dataInA[i]),
             .rhs(port.dataInB[i]),
             .is_divide(port.is_divide[i]),
@@ -110,6 +111,7 @@ module FPDivSqrtUnit(FPDivSqrtUnitIF.FPDivSqrtUnit port, RecoveryManagerIF.FPDiv
             if (flush[i]) begin
                 nextPhase[i] = DIVIDER_PHASE_FREE;
             end
+            rst_divider[i] = port.rst | flush[i];
 
             // 現状 acquire が issue ステージからくるので，次のサイクルの状態でフリーか
             // どうかを判定する必要がある

--- a/Processor/Src/MulDivUnit/MulDivUnit.sv
+++ b/Processor/Src/MulDivUnit/MulDivUnit.sv
@@ -55,7 +55,7 @@ module MulDivUnit(MulDivUnitIF.MulDivUnit port, RecoveryManagerIF.MulDivUnit rec
     for (genvar i = 0; i < MULDIV_ISSUE_WIDTH; i++) begin : BlockDivUnit
         DividerUnit divUnit(
             .clk(port.clk),
-            .rst(port.rst),
+            .rst(port.rst | flush[i]),
             .req(port.divReq[i]),
             .fuOpA_In(port.dataInA[i]),
             .fuOpB_In(port.dataInB[i]),

--- a/Processor/Src/MulDivUnit/MulDivUnit.sv
+++ b/Processor/Src/MulDivUnit/MulDivUnit.sv
@@ -49,13 +49,14 @@ module MulDivUnit(MulDivUnitIF.MulDivUnit port, RecoveryManagerIF.MulDivUnit rec
     logic finished[MULDIV_ISSUE_WIDTH];
 
     logic flush[MULDIV_ISSUE_WIDTH];
+    logic rst_divider[MULDIV_ISSUE_WIDTH];
     ActiveListIndexPath regActiveListPtr[MULDIV_ISSUE_WIDTH];
     ActiveListIndexPath nextActiveListPtr[MULDIV_ISSUE_WIDTH];
 
     for (genvar i = 0; i < MULDIV_ISSUE_WIDTH; i++) begin : BlockDivUnit
         DividerUnit divUnit(
             .clk(port.clk),
-            .rst(port.rst | flush[i]),
+            .rst(rst_divider[i]),
             .req(port.divReq[i]),
             .fuOpA_In(port.dataInA[i]),
             .fuOpB_In(port.dataInB[i]),
@@ -140,6 +141,7 @@ module MulDivUnit(MulDivUnitIF.MulDivUnit port, RecoveryManagerIF.MulDivUnit rec
             if (flush[i]) begin
                 nextPhase[i] = DIVIDER_PHASE_FREE;
             end
+            rst_divider[i] = port.rst | flush[i];
 
             // 現状 acquire が issue ステージからくるので，次のサイクルの状態でフリーか
             // どうかを判定する必要がある


### PR DESCRIPTION
When the divide instruction is flushed, the divider allocated by the instruction must be released, and its state must be reset.
However, the internal state of the DividerUnit and FP32DivSqrter was not reset.
fixed this bug so that the divider is reset correctly on a flush.