### PR TITLE
Fix decoding of instructions with undefined funct

### DIFF
--- a/Processor/Src/Decoder/Decoder.sv
+++ b/Processor/Src/Decoder/Decoder.sv
@@ -1147,12 +1147,22 @@ function automatic void RISCV_EmitSystemOp(
         opInfo.mopType = MOP_TYPE_INT;
         opInfo.mopSubType.intType = INT_MOP_TYPE_ALU;
         systemOp.envCode = ENV_BREAK;
+        undefined = isfSystem.rd != 0 || isfSystem.rs1 != 0 || isfSystem.funct3 != 0;
     end
     else begin
         unique case(SystemFunct12'(isfSystem.funct12))
-            SYSTEM_FUNCT12_ECALL:  systemOp.envCode = ENV_CALL;
-            SYSTEM_FUNCT12_EBREAK: systemOp.envCode = ENV_BREAK;
-            SYSTEM_FUNCT12_MRET:   systemOp.envCode = ENV_MRET;
+            SYSTEM_FUNCT12_ECALL: begin 
+                systemOp.envCode = ENV_CALL;
+                undefined = isfSystem.rd != 0 || isfSystem.rs1 != 0;
+            end
+            SYSTEM_FUNCT12_EBREAK: begin
+                systemOp.envCode = ENV_BREAK;
+                undefined = isfSystem.rd != 0 || isfSystem.rs1 != 0;
+            end
+            SYSTEM_FUNCT12_MRET: begin
+                systemOp.envCode = ENV_MRET;
+                undefined = isfSystem.rd != 0 || isfSystem.rs1 != 0;
+            end
             default: begin// Unknown
                 systemOp.envCode = ENV_BREAK;            
                 undefined = TRUE;

--- a/Processor/Src/Decoder/Decoder.sv
+++ b/Processor/Src/Decoder/Decoder.sv
@@ -735,7 +735,22 @@ function automatic void RISCV_EmitMemOp(
     opInfo.valid = TRUE;
 
     opInfo.unsupported = FALSE;
-    opInfo.undefined = FALSE;
+    if (isLoad) begin
+        opInfo.undefined = !(memFunct3 inside {
+            MEM_FUNCT3_SIGNED_BYTE,
+            MEM_FUNCT3_SIGNED_HALF_WORD,
+            MEM_FUNCT3_WORD,
+            MEM_FUNCT3_UNSIGNED_BYTE,
+            MEM_FUNCT3_UNSIGNED_HALF_WORD
+            });
+    end
+    else begin
+        opInfo.undefined = !(memFunct3 inside {
+            MEM_FUNCT3_SIGNED_BYTE,
+            MEM_FUNCT3_SIGNED_HALF_WORD,
+            MEM_FUNCT3_WORD
+        });
+    end 
 
     // Serialized
     opInfo.serialized = FALSE;
@@ -1268,7 +1283,7 @@ function automatic void RISCV_EmitFPMemOp(
     opInfo.valid = TRUE;
 
     opInfo.unsupported = FALSE;
-    opInfo.undefined = FALSE;
+    opInfo.undefined = memFunct3 != MEM_FUNCT3_WORD;
 
     // Serialized
     opInfo.serialized = FALSE;
@@ -1324,6 +1339,7 @@ function automatic void RISCV_EmitFPOp(
 
     FPU_Code fpuCode;
     Rounding_Mode rm;
+    logic undefined;
 
     isfR = isf;
     rv32fFunct3 = RV32FFunct3'(isfR.funct3);
@@ -1331,7 +1347,7 @@ function automatic void RISCV_EmitFPOp(
     fcvtfunct5  = FCVTFunct5'(isfR.rs2);
     rm = Rounding_Mode'(isfR.funct3);
 
-    RISCV_DecodeFPOpFunct3( fpuCode, rv32fFunct3, rv32fFunct7, fcvtfunct5);
+    RISCV_DecodeFPOpFunct3( fpuCode, undefined, rv32fFunct3, rv32fFunct7, fcvtfunct5);
     dstFP   = !(fpuCode inside {FC_FCVT_WS, FC_FCVT_WUS, FC_FMV_XW, FC_FEQ, FC_FLT, FC_FLE, FC_FCLASS});
     rs1FP   = !(fpuCode inside {FC_FCVT_SW, FC_FCVT_SWU, FC_FMV_WX});
     readrs2 = !(fpuCode inside {FC_SQRT, FC_FCVT_SW, FC_FCVT_SWU, FC_FCVT_WS, FC_FCVT_WUS, FC_FMV_WX, FC_FMV_XW, FC_FCLASS});
@@ -1374,7 +1390,7 @@ function automatic void RISCV_EmitFPOp(
 
     // 未定義命令
     opInfo.unsupported = FALSE;
-    opInfo.undefined = FALSE;
+    opInfo.undefined = undefined;
 
     // Serialized
     opInfo.serialized = FALSE;
@@ -1468,7 +1484,7 @@ function automatic void RISCV_EmitFPFMAOp(
 
     // 未定義命令
     opInfo.unsupported = FALSE;
-    opInfo.undefined = FALSE;
+    opInfo.undefined = isfR4.funct2 != '0;
 
     // Serialized
     opInfo.serialized = FALSE;

--- a/Processor/Src/Decoder/OpFormat.sv
+++ b/Processor/Src/Decoder/OpFormat.sv
@@ -885,7 +885,7 @@ function automatic void RISCV_DecodeFPOpFunct3(
         RV32F_FUNCT7_FSQRT : begin
             fpuCode = FC_SQRT;
             undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN})
-                            || (fcvtfunct5 != 0);
+                            || (fcvtfunct5 != FCVT_FUNCT5_SIGNED);
         end
         RV32F_FUNCT7_FSGNJ : begin
             //Todo: ここにfpTypeの代入かけるのか

--- a/Processor/Src/Decoder/OpFormat.sv
+++ b/Processor/Src/Decoder/OpFormat.sv
@@ -859,25 +859,33 @@ endfunction
 
 function automatic void RISCV_DecodeFPOpFunct3(
     output FPU_Code fpuCode,
+    output logic undefined,
     input RV32FFunct3 rv32ffunct3,
     input RV32FFunct7 rv32ffunct7,
     input FCVTFunct5  fcvtfunct5
 );
+    undefined = FALSE;
     case(rv32ffunct7)
         RV32F_FUNCT7_FADD : begin
             fpuCode = FC_ADD;
+            undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
         end
         RV32F_FUNCT7_FSUB : begin
             fpuCode = FC_SUB;
+            undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
         end
         RV32F_FUNCT7_FMUL : begin
             fpuCode = FC_MUL;
+            undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
         end
         RV32F_FUNCT7_FDIV : begin
             fpuCode = FC_DIV;
+            undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
         end
         RV32F_FUNCT7_FSQRT : begin
             fpuCode = FC_SQRT;
+            undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN})
+                            || (fcvtfunct5 != 0);
         end
         RV32F_FUNCT7_FSGNJ : begin
             //Todo: ここにfpTypeの代入かけるのか
@@ -893,6 +901,7 @@ function automatic void RISCV_DecodeFPOpFunct3(
                 end
                 default: begin
                     fpuCode = FC_SGNJX;
+                    undefined = TRUE;
                 end
             endcase
         end
@@ -900,24 +909,38 @@ function automatic void RISCV_DecodeFPOpFunct3(
             if (rv32ffunct3.fminfmaxFunct3 == FMIN_FMAX_FUNCT3_FMIN) begin
                 fpuCode = FC_FMIN;
             end
+            else if (rv32ffunct3.fminfmaxFunct3 == FMIN_FMAX_FUNCT3_FMAX) begin
+                fpuCode = FC_FMAX;
+            end
             else begin
                 fpuCode = FC_FMAX;
+                undefined = TRUE;
             end
         end
         RV32F_FUNCT7_FCVT_WS : begin
             if (fcvtfunct5 == FCVT_FUNCT5_SIGNED) begin
                 fpuCode = FC_FCVT_WS;
+                undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
+            end
+            else if (fcvtfunct5 == FCVT_FUNCT5_UNSIGNED) begin
+                fpuCode = FC_FCVT_WUS;
+                undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
             end
             else begin
                 fpuCode = FC_FCVT_WUS;
+                undefined = TRUE;
             end
         end
         RV32F_FUNCT7_FCLASS_FMV_XW : begin
             if (rv32ffunct3.fclassfmvFunct3 == FCLASS_FMV_FUNCT3_FCLASS) begin
                 fpuCode = FC_FCLASS;
             end
+            else if (rv32ffunct3.fclassfmvFunct3 == FCLASS_FMV_FUNCT3_FMV_XW) begin
+                fpuCode = FC_FMV_XW;
+            end
             else begin
                 fpuCode = FC_FMV_XW;
+                undefined = TRUE;
             end
         end
         RV32F_FUNCT7_FEQ_FLT_FLE : begin
@@ -933,22 +956,31 @@ function automatic void RISCV_DecodeFPOpFunct3(
                 end
                 default: begin
                     fpuCode = FC_FLE;
+                    undefined = TRUE;
                 end
             endcase
         end
         RV32F_FUNCT7_FCVT_SW : begin
             if (fcvtfunct5 == FCVT_FUNCT5_SIGNED) begin
                 fpuCode = FC_FCVT_SW;
+                undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
+            end
+            else if (fcvtfunct5 == FCVT_FUNCT5_UNSIGNED) begin
+                fpuCode = FC_FCVT_SWU;
+                undefined = !(rv32ffunct3 inside {RM_RNE, RM_RTZ, RM_RDN, RM_RUP, RM_RMM, RM_DYN});
             end
             else begin
                 fpuCode = FC_FCVT_SWU;
+                undefined = TRUE;
             end
         end
         RV32F_FUNCT7_FMV_WX : begin
             fpuCode = FC_FMV_WX;
+            undefined = rv32ffunct3 != '0;
         end
         default: begin
             fpuCode = FC_FMV_WX;
+            undefined = TRUE;
         end
     endcase
 endfunction


### PR DESCRIPTION
This PR includes the following fix:
* Modified the decoder to assert the undefined flag when decoding an instruction with an undefined funct or operands.

With this fix, executing an instruction with an undefined funct will now trigger an invalid instruction exception.
